### PR TITLE
Swapped 'start page' for heading

### DIFF
--- a/app/views/sprint-five/resume-start.html
+++ b/app/views/sprint-five/resume-start.html
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-      Start page
+      Buy for your school: step by step
     </h1>
     </div>
   </div>

--- a/app/views/sprint-five/resume-start.html
+++ b/app/views/sprint-five/resume-start.html
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-      Buy for your school: step by step
+      {{serviceName}}
     </h1>
     </div>
   </div>


### PR DESCRIPTION
The heading was 'start page' so I've changed it to 'Buy for your school: step by step'